### PR TITLE
Add hostname to category list for groups

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,4 +37,5 @@ jobs:
       - name: Upload coverage report to Coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: coveralls

--- a/dotgit/flists.py
+++ b/dotgit/flists.py
@@ -2,6 +2,8 @@ import logging
 import os
 import re
 
+import dotgit.info as info
+
 
 class Filelist:
     def __init__(self, fname):
@@ -21,6 +23,8 @@ class Filelist:
                 if '=' in line:
                     group, categories = line.split('=')
                     categories = categories.split(',')
+                    if group == info.hostname:
+                        categories.append(info.hostname)
                     self.groups[group] = categories
                 # file
                 else:

--- a/tests/test_flists.py
+++ b/tests/test_flists.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import socket
 
 from dotgit.flists import Filelist
 
@@ -19,10 +20,18 @@ class TestFilelist:
         assert flist.files == {}
 
     def test_group(self, tmp_path):
+        # Test where group name != hostname
         fname = self.write_flist(tmp_path, 'group=cat1,cat2,cat3')
 
         flist = Filelist(fname)
         assert flist.groups == {'group': ['cat1', 'cat2', 'cat3']}
+        assert flist.files == {}
+
+        # Test where group name == hostname
+        fname = self.write_flist(tmp_path, socket.gethostname() + '=cat1,cat2,cat3')
+
+        flist = Filelist(fname)
+        assert flist.groups == {socket.gethostname(): ['cat1', 'cat2', 'cat3', socket.gethostname()]}
         assert flist.files == {}
 
     def test_common_file(self, tmp_path):


### PR DESCRIPTION
The group that gets applied must match the hostname,
but if there are host-specific files they are currently
ignored.

Take the following `filelist`:
```
laptop=vim,shell

.vimrc:vim
.bash_profile:shell
.gitconfig:laptop
```
On the computer with hostname `laptop`, the files
`.vimrc` and `.bash_profile` would be handled as
intended, but `.gitconfig` would be ignored unless
you modify the group line to look like this:
```
laptop=vim,shell,laptop
```

In order to allow for different versions of files on
different hosts, when the group name matches the current
hostname add that to the list of categories for the group.