### PR TITLE
implement category priorities

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -23,6 +23,9 @@ When you run dotgit all the files in the filelist that are not part of the
 active categories will be ignored. You can run dotgit with two verbose flags
 ``-vv`` to see what categories are currently active.
 
+In case you try to restore a group which contains a file that is tagged by
+multiple categories, the latest category in the list takes precedence.
+
 Flags
 =====
 

--- a/dotgit/flists.py
+++ b/dotgit/flists.py
@@ -52,18 +52,28 @@ class Filelist:
         # flatten category list
         categories = [c for cat in categories for c in cat]
 
+        # later categories take precedence over earlier ones
+        cat_priority = {c: i for i, c in enumerate(categories)}
+
         files = {}
+        file_priority = {}
         for path in self.files:
             for group in self.files[path]:
                 cat_list = group['categories']
-                if set(categories) & set(cat_list):
-                    if path in files:
+                matching = set(categories) & set(cat_list)
+                if matching:
+                    priority = max(cat_priority[c] for c in matching)
+                    if path not in files:
+                        files[path] = group
+                        file_priority[path] = priority
+                    elif priority > file_priority[path]:
+                        files[path] = group
+                        file_priority[path] = priority
+                    elif priority == file_priority[path]:
                         logging.error('multiple category lists active for '
                                       f'{path}: {files[path]["categories"]} '
                                       f'and {cat_list}')
                         raise RuntimeError
-                    else:
-                        files[path] = group
 
         return files
 

--- a/tests/test_flists.py
+++ b/tests/test_flists.py
@@ -121,6 +121,116 @@ class TestFilelist:
         with pytest.raises(RuntimeError):
             flist.activate(['cat2'])
 
+    def test_arbitration_group_later_wins(self, tmp_path):
+        """Later category in group takes precedence over earlier."""
+        # group defines order: common(0), alias(1), zsh(2), vim(3)
+        fname = self.write_flist(tmp_path,
+                                 'myhost=common,alias,zsh,vim\n'
+                                 '.vimrc\n'          # common (index 0)
+                                 '.vimrc:vim\n')     # vim (index 3)
+
+        flist = Filelist(fname)
+        # simulates `dotgit restore` on myhost: ['common', 'myhost']
+        # expands to ['common', 'common', 'alias', 'zsh', 'vim', 'myhost']
+        # vim (index 4) > common (index 1), so vim version wins
+        result = flist.activate(['common', 'myhost'])
+        assert result == {
+            '.vimrc': {
+                'categories': ['vim'],
+                'plugin': 'plain',
+            }}
+
+    def test_arbitration_group_common_fallback(self, tmp_path):
+        """On a different host, only common matches as fallback."""
+        fname = self.write_flist(tmp_path,
+                                 'myhost=common,alias,zsh,vim\n'
+                                 '.profile\n'           # common
+                                 '.profile:vim\n')      # vim — only in myhost group
+
+        flist = Filelist(fname)
+        # on 'otherhost' (no group defined), categories stay ['common', 'otherhost']
+        # 'vim' is not in the active set, so only common matches
+        result = flist.activate(['common', 'otherhost'])
+        assert result == {
+            '.profile': {
+                'categories': ['common'],
+                'plugin': 'plain',
+            }}
+
+    def test_arbitration_group_order_matters(self, tmp_path):
+        """Position inside group determines which category wins the file."""
+        # alias is before zsh in the group, so zsh has higher priority
+        fname = self.write_flist(tmp_path,
+                                 'myhost=alias,zsh\n'
+                                 '.config:alias\n'
+                                 '.config:zsh\n')
+
+        flist = Filelist(fname)
+        result = flist.activate(['common', 'myhost'])
+        # flattened: ['common', 'alias', 'zsh', 'myhost']
+        # zsh (index 2) > alias (index 1) → zsh wins
+        assert result == {
+            '.config': {
+                'categories': ['zsh'],
+                'plugin': 'plain',
+            }}
+
+    def test_arbitration_group_filelist_entry_order_irrelevant(self, tmp_path):
+        """Order of entries in filelist doesn't matter; group order does."""
+        # specific entry listed BEFORE common entry in filelist
+        fname = self.write_flist(tmp_path,
+                                 'myhost=common,zsh\n'
+                                 '.zshrc:zsh\n'
+                                 '.zshrc\n')
+
+        flist = Filelist(fname)
+        result = flist.activate(['common', 'myhost'])
+        # flattened: ['common', 'common', 'zsh', 'myhost']
+        # zsh (index 2) > common (index 1) → zsh wins regardless of filelist order
+        assert result == {
+            '.zshrc': {
+                'categories': ['zsh'],
+                'plugin': 'plain',
+            }}
+
+    def test_arbitration_group_with_plugin(self, tmp_path):
+        """Arbitration works correctly with non-default plugins."""
+        fname = self.write_flist(tmp_path,
+                                 'myhost=common,ssh\n'
+                                 '.ssh/config|encrypt\n'
+                                 '.ssh/config:ssh|encrypt\n')
+
+        flist = Filelist(fname)
+        result = flist.activate(['common', 'myhost'])
+        assert result == {
+            '.ssh/config': {
+                'categories': ['ssh'],
+                'plugin': 'encrypt',
+            }}
+
+    def test_arbitration_group_no_match(self, tmp_path):
+        """File with category not in any active group is excluded."""
+        fname = self.write_flist(tmp_path,
+                                 'myhost=alias,zsh\n'
+                                 '.profile:vim\n')
+
+        flist = Filelist(fname)
+        # vim is not in the myhost group, and not in ['common', 'myhost']
+        result = flist.activate(['common', 'myhost'])
+        assert result == {}
+
+    def test_arbitration_group_equal_priority_raises(self, tmp_path):
+        """Two entries matching the same highest-priority category is an error."""
+        fname = self.write_flist(tmp_path,
+                                 'myhost=alias,zsh\n'
+                                 'file:alias,zsh\n'    # matches zsh (highest)
+                                 'file:zsh\n')         # also matches zsh
+
+        flist = Filelist(fname)
+        # both entries have max priority from 'zsh' → ambiguous
+        with pytest.raises(RuntimeError):
+            flist.activate(['common', 'myhost'])
+
     def test_manifest(self, tmp_path):
         fname = self.write_flist(tmp_path,
                                  'group=cat1,cat2\ncfile\nnfile:cat1,cat2\n'


### PR DESCRIPTION
## Motivation
This PR introduces category priorities. This can be useful when you need to override a common tool setting with machine specific setting. In general, it allows a way to make category take precedence by listing it after another category.

Most people use `dotgit restore` without explicit category, where `common` and `hostname` categories are implicitly added. `common` category has lowest priority because it's added first. `hostname` category has highest priority because it is appended last.

For example:
```shell
computer=alias,zsh,vim,git

.profile
.profile:computer

.zshenv:zsh
.zshenv:computer
```

Both of these file configs cause error.

First one is problematic when restoring without explicit category.
```shell
$> dotgit restore 
multiple category lists active for .profile: ['common'] and ['computer'] 
```
Second one fails in similar manner.
```shell
$> dotgit restore 
multiple category lists active for .profile: ['zsh'] and ['computer'] 
```

### Implementation
Categories are prioritized based on their order after category list is flattened during activation. This allows fine tuning configurations and having general configs overriden by specific configs.

**DISCLAIMER:** Code and tests have been generated by AI agent. I've added a sentence do docs more as a placeholder. Maybe cookbook could be expanded with more examples and with more complex `filelist` examples. 